### PR TITLE
use a smaller splash font size on smaller screens

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -159,6 +159,12 @@ main {
     font-weight: 300;
 }
 
+@media screen and (max-width: 640px) {
+  #splash h1 {
+    font-size: calc(9vw + 8px);
+  }
+}
+
 /* Mission */
 #mission {
     width: 80%;


### PR DESCRIPTION
* uses a variable font size based on viewport width for the splash-sized header, starting at viewports 640px and narrower