### PR TITLE
Some style fixes

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -37,7 +37,7 @@
         <section id="splash">
             <div class="container">
                 <h1>Rust Foundation</h1>
-                <h2>A new approach to sustaining and growing a large, participatory, open source ecosystem<h2>
+                <h2>A new approach to sustaining and growing a large, participatory, open source ecosystem</h2>
             </div>
         </section>
     </header>

--- a/css/index.css
+++ b/css/index.css
@@ -152,7 +152,8 @@ main {
 #splash h1 {
     font-size: 5em;
     font-weight: 900;
-    margin: 0;
+    margin: 0 -5% 0 0;
+    overflow-x: hidden;
 }
 #splash h2 {
     font-family: "Raleway", sans-serif;
@@ -180,6 +181,12 @@ main {
     font-family: "Raleway", sans-serif;
     font-weight: 300;
     line-height: 2em;
+}
+#mission .flex {
+  display: flex;
+}
+#mission .flex > *:not(:first-child) {
+  margin-left: 1em;
 }
 
 /* 404 */
@@ -278,6 +285,7 @@ footer p {
     display: inline;
 }
 footer img {
+    min-width: 160px;
     width: 15%;
     margin-bottom: 1em;
 }
@@ -344,6 +352,7 @@ footer .container {
 }
 
 .memberslist {
+  padding: 0;
   text-align: center;
 }
 
@@ -368,13 +377,13 @@ footer .container {
 .post h1, .event h1, .posts h1, .events h1, .board h1, .contact h1, .members h1 {
   font-size: 5em;
   font-weight: 900;
-  margin: 1em 0; 
+  margin: 1em 0;
 }
 
 .post h2, .event h2 {
   font-family: 'Raleway', sans-serif;
   font-weight: 300;
-  margin: 1em 0; 
+  margin: 1em 0;
 }
 
 .post-tags, .event-tags {

--- a/index.njk
+++ b/index.njk
@@ -7,8 +7,10 @@ eleventyNavigation:
 <section class="container" id="mission">
     <h1>Good software is built by happy, well-supported people</h1>
     <h2>The Rust Foundation is an independent non-profit organization to steward the <a href="https://www.rust-lang.org">Rust programming language</a> and ecosystem, with a unique focus on supporting the set of maintainers that govern and develop the project.</h2>
-    <div class="cta-gradient button"><a href="/posts/2021-02-08-hello-world/">Learn more about how we're different</a></div>
-    <div class="cta-white button"><a href="/info/contact">Get in touch</a></div>
+    <div class="flex">
+      <div class="cta-gradient button"><a href="/posts/2021-02-08-hello-world/">Learn more about how we're different</a></div>
+      <div class="cta-white button"><a href="/info/contact">Get in touch</a></div>
+    </div>
 </section>
 
 <section class="container" id="posts">


### PR DESCRIPTION
I found a bug in the 4 styles in the phone size and fixed it.

- [1] The "Rust Foundation" text in the h1 at the top was going through the parent element. This can be prevented by using `overflow-x: hidden`, but I wanted the text to be visible on the right side for design purposes, so I used negative margin.

|before|after|
|:-:|:-:|
|![スクリーンショット 2021-02-09 10 35 17](https://user-images.githubusercontent.com/12035578/107306096-94a7e780-6ac7-11eb-94d0-1206484a3485.png)|![スクリーンショット 2021-02-09 10 51 09](https://user-images.githubusercontent.com/12035578/107306102-9bcef580-6ac7-11eb-928d-cb71a74222dc.png)|

- [2] The links in the mission column were next to each other and hard to push, so I separated them a bit. The links are now aligned horizontally.

|before|after|
|:-:|:-:|
|![スクリーンショット 2021-02-09 10 44 00](https://user-images.githubusercontent.com/12035578/107306243-e6507200-6ac7-11eb-92d4-8eb92894ac9a.png)|![スクリーンショット 2021-02-09 10 55 34](https://user-images.githubusercontent.com/12035578/107306257-ec465300-6ac7-11eb-8c8a-13f60c65d5f3.png)|


- [3] The members section was not centered, and because of this, there was a bit of useless white space in the `/members` page. To make it easier to see the whitespace, I've specified it in purple.

|before|member page|after|
|:-:|:-:|:-:|
|![スクリーンショット 2021-02-09 10 56 16](https://user-images.githubusercontent.com/12035578/107306467-41826480-6ac8-11eb-9ed3-19e24b8b1512.png)|![スクリーンショット 2021-02-09 11 02 11](https://user-images.githubusercontent.com/12035578/107306479-46dfaf00-6ac8-11eb-88c6-e8fd2761b46f.png)|![スクリーンショット 2021-02-09 11 14 38](https://user-images.githubusercontent.com/12035578/107306502-4fd08080-6ac8-11eb-91b0-0b95c1f96876.png)|

- [4] The Rust Foundation logo in the footer was getting too small, so I added `min-width: 160px` as the minimum size for the logo in Header.

|before|after|
|:-:|:-:|
|![スクリーンショット 2021-02-09 11 04 23](https://user-images.githubusercontent.com/12035578/107306605-81494c00-6ac8-11eb-8175-5324372dc699.png)|![スクリーンショット 2021-02-09 11 04 29](https://user-images.githubusercontent.com/12035578/107306613-84dcd300-6ac8-11eb-8586-8eeb78cb6be3.png)|