### PR TITLE
Fix bug in footer link hover color

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -300,7 +300,7 @@ footer img {
     width: 15%;
     margin-bottom: 1em;
 }
-footer a[href], footer a[href]:visited, footer a[href]:visited {
+footer a[href], footer a[href]:visited, footer a[href]:hover {
     color: var(--white);
 }
 footer .container {


### PR DESCRIPTION
When you hover over a link in the footer, it turns the same color as the background and cannot be read. This patch makes it stay white instead.

It also removes a superfluous `footer a[href]:visited` selector.