### PR TITLE
Remove 11ty sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-# These are supported funding model platforms
-open_collective: 11ty


### PR DESCRIPTION
Currently github has a sponsor button, but for 11ty, because of the template

![image](https://user-images.githubusercontent.com/28781354/117438229-2f7a5b80-af29-11eb-9bd2-495e0c8a40d2.png)
