### PR TITLE
Add specific Meetings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # foundation.rust-lang.org
+
+The website for the Rust Foundation
+
+## Running the site locally
+
+The site uses Eleventy. https://www.11ty.dev/docs/usage/
+
+From the root of the website GitHub repo...
+
+`npm install`
+`npx @11ty/eleventy --serve`

--- a/_includes/eventslist.njk
+++ b/_includes/eventslist.njk
@@ -1,4 +1,4 @@
-<ol class="postlist" style="counter-reset: start-from {{ (eventslistCounter or eventslist.length) }}">
+<ol class="postlist" style="counter-reset: start-from {{ (eventslistCounter or eventslist.length + 1) }}">
 {% for event in eventslist | reverse %}
   <li class="postlist-item{% if event.url == url %} postlist-item-active{% endif %}">
     <a href="{{ event.url | url }}" class="postlist-link">{% if event.data.title %}{{ event.data.title }}{% else %}<code>{{ event.url }}</code>{% endif %}</a>

--- a/_includes/layouts/meeting.njk
+++ b/_includes/layouts/meeting.njk
@@ -1,0 +1,42 @@
+---
+layout: layouts/base.njk
+templateClass: tmpl-meeting
+---
+<section class="container meeting">
+    <h1>{{ title }}</h1>
+    <h2>{{ description }}</h2>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+    <div class="attachments">
+        {%- if attachments != undefined -%}
+            Artifacts:
+            <ul>
+            {% for name, aUrl in attachments %}
+                <li><a href="{{ aUrl | url }}">{{ name | safe }}</a></li>
+            {% endfor %}
+            </ul>
+
+            Please note that any policies or documents approved here may not be
+            the latest versions approved by the Board.
+        {%- endif -%}
+    </div>
+  <div class="meeting-tags">
+    Tagged:
+    {% for tag in tags %}
+      {%- if collections.tagList.indexOf(tag) != -1 -%}
+      {% set tagUrl %}/tags/{{ tag }}/{% endset %}
+      <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
+      {%- endif -%}
+    {% endfor %}
+  </div>
+    <h2 class="date">{{ date }}</h2>
+
+    <hr>
+    <ul>
+        {%- set nextMeeting = collections.meetings | getNextCollectionItem(page) %}
+        {%- if nextMeeting %}<li>Next: <a href="{{ nextMeeting.url | url }}">{{ nextMeeting.data.title }}</a></li>{% endif %}
+        {%- set previousMeeting = collections.meetings | getPreviousCollectionItem(page) %}
+        {%- if previousMeeting %}<li>Previous: <a href="{{ previousMeeting.url | url }}">{{ previousMeeting.data.title }}</a></li>{% endif %}
+    </ul>
+</section>

--- a/_includes/meetingslist.njk
+++ b/_includes/meetingslist.njk
@@ -1,0 +1,14 @@
+<ol class="postlist" style="counter-reset: start-from {{ (meetingslistCounter or meetingslist.length + 1) }}">
+{% for meeting in meetingslist | reverse %}
+  <li class="postlist-item{% if meeting.url == url %} postlist-item-active{% endif %}">
+    <a href="{{ meeting.url | url }}" class="postlist-link">{% if meeting.data.title %}{{ meeting.data.title }}{% else %}<code>{{ meeting.url }}</code>{% endif %}</a>
+    <time class="postlist-date" datetime="{{ meeting.date | htmlDateString }}">{{ meeting.date | readableDate }}</time>
+    {% for tag in meeting.data.tags %}
+      {%- if collections.tagList.indexOf(tag) != -1 -%}
+      {% set tagUrl %}/tags/{{ tag }}/{% endset %}
+      <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
+      {%- endif -%}
+    {% endfor %}
+  </li>
+{% endfor %}
+</ol>

--- a/css/index.css
+++ b/css/index.css
@@ -204,6 +204,10 @@ main {
     border-bottom: 1px var(--lightorange) dotted;
     padding-bottom: 4em;
 }
+#meetings {
+  border-bottom: 1px var(--lightorange) dotted;
+  padding-bottom: 4em;
+}
 #mission h1 {
     margin: 2em 0 1em 0;
     font-size: 2em;
@@ -407,7 +411,7 @@ footer .container {
   }
 }
 
-.policy h1, .post h1, .event h1, .posts h1, .events h1, .board h1, .contact h1, .members h1, .become h1 {
+.policy h1, .post h1, .event h1, .posts h1, .events h1, .meetings h1, .board h1, .contact h1, .members h1, .become h1 {
   font-size: 3.25em;
   font-weight: 900;
   margin: 1em 0;

--- a/index.njk
+++ b/index.njk
@@ -27,7 +27,7 @@ eleventyNavigation:
     <h1>Events</h1>
 
     {% set eventslist = collections.events | head(-3) %}
-    {% set eventslistCounter = collections.events | length %}
+    {% set eventslistCounter = collections.events | length + 1 %}
     {% include "eventslist.njk" %}
 
     <p>More events can be found in <a href="{{ '/events/' | url }}">the archive</a>.</p>

--- a/meetings.njk
+++ b/meetings.njk
@@ -1,0 +1,13 @@
+---
+layout: layouts/base.njk
+permalink: /meetings/
+eleventyNavigation:
+  key: Meetings
+  order: 2
+---
+<section class="container meetings">
+    <h1>Meetings</h1>
+
+    {% set meetingslist = collections.meetings %}
+    {% include "meetingslist.njk" %}
+</section>

--- a/meetings/2021-02-09-board-meeting.md
+++ b/meetings/2021-02-09-board-meeting.md
@@ -11,5 +11,5 @@ attachments:
     'Exhibit B - Conflict of Interest Policy': '/static/2021-02-09-package/Exhibit B - Conflict of Interest Policy.pdf'
     'Exhibit C - Intellectual Property Policy': '/static/2021-02-09-package/Exhibit C - Intellectual Property Policy.pdf'
     'Exhibit D - Code of Conduct': '/static/2021-02-09-package/Exhibit D - Code of Conduct.pdf'
-layout: layouts/event.njk
+layout: layouts/meeting.njk
 ---

--- a/meetings/2021-03-09-board-meeting.md
+++ b/meetings/2021-03-09-board-meeting.md
@@ -8,5 +8,5 @@ attachments:
     'Presentation': '/static/2021-03-09-package/Public Session Presentation.pdf'
     'Minutes': '/static/2021-03-09-package/2021-03-09 Meeting Minutes.pdf'
     'Exhibit A - Conflict of Interest Policy': '/static/2021-03-09-package/Exhibit A - Conflict of Interest Policy.pdf'
-layout: layouts/event.njk
+layout: layouts/meeting.njk
 ---

--- a/meetings/2021-04-13-board-meeting.md
+++ b/meetings/2021-04-13-board-meeting.md
@@ -4,5 +4,5 @@ description: The Foundation Board of Directors will convene for a monthly meetin
 date: 2021-04-13
 tags:
   - board meeting
-layout: layouts/event.njk
+layout: layouts/meeting.njk
 ---

--- a/meetings/2021-05-11-board-meeting.md
+++ b/meetings/2021-05-11-board-meeting.md
@@ -8,5 +8,5 @@ attachments:
     'Presentation': '/static/2021-05-11-package/Public Session Presentation.pdf'
     'Minutes': '/static/2021-05-11-package/2021-05-11 Meeting Minutes.pdf'
     'Exhibit B - Statement on Global Regulations': '/static/2021-05-11-package/Exhibit B - Statement on Global Regulations.pdf'
-layout: layouts/event.njk
+layout: layouts/meeting.njk
 ---

--- a/meetings/meetings.json
+++ b/meetings/meetings.json
@@ -1,0 +1,5 @@
+{
+  "tags": [
+    "meetings"
+  ]
+}


### PR DESCRIPTION
Meetings and Events were combined into one page under a heading called "Events". Separate them out into two separate entities. "Events" and "Meetings"

Tested the site locally

![Screen Shot 2021-08-25 at 4 04 03 PM](https://user-images.githubusercontent.com/3757713/130875646-ac85ffe8-2b82-42f0-9780-f9dbe7713439.png)
![Screen Shot 2021-08-25 at 4 03 53 PM](https://user-images.githubusercontent.com/3757713/130875649-1984a46b-2ec4-462b-ac9e-7209c7d83535.png)
![Screen Shot 2021-08-25 at 4 03 49 PM](https://user-images.githubusercontent.com/3757713/130875652-b1fce86e-3531-4c8e-9e4c-4bbe10230345.png)
