### PR TITLE
Add Analytics

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -10,6 +10,7 @@
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
     <link rel="alternate" href="{{ metadata.jsonfeed.path | url }}" type="application/json" title="{{ metadata.title }}">
     {% include "metatags.njk" %}
+    <script defer data-domain="foundation.rust-lang.org" src="https://plausible.io/js/plausible.js"></script>
   </head>
   <body>
     <header>

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -10,6 +10,7 @@
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
     <link rel="alternate" href="{{ metadata.jsonfeed.path | url }}" type="application/json" title="{{ metadata.title }}">
     {% include "metatags.njk" %}
+    <script defer data-domain="foundation.rust-lang.org" src="https://plausible.io/js/plausible.js"></script>
   </head>
   <body>
     <header>


### PR DESCRIPTION
## TL;DR

The Rust Foundation has a mission to support Rust maintainers. We require various levels of feedback to do our job well and thus propose adding the collection of basic website analytics, particularly page views, in order to understand what content works well and what the Foundation should be focused on producing. We suggest a solution called [Plausible](https://plausible.io) that provides privacy-friendly analytics.


## Analytics Proposal

The Rust Foundation’s mission is to steward the Rust programming language and ecosystem. In order to excel at this, we require various levels of data and feedback to ensure it is focusing its resources appropriately. And one of the key areas of data is derived from our online presence.

We maintain a [website](https://foundation.rust-lang.org) as a vehicle for Foundation news and information. The website is [open source](https://github.com/rustfoundation/foundation.rust-lang.org), available for the world to see. Currently, the website does not have an integrated analytics solution to provide basic site statistical data.

We strongly support high privacy standards, particularly for visitors to the website. It does not want to track users. It wants to be strictly GDPR compliant. That said, we would also like to be able to understand what content performs well, make informed decisions about future content, and be able to provide high level site statistical data to its members.

In addition, like most other foundations, the Rust Foundation is member driven. The Foundation’s members contribute money and resources in support of the Foundation’s mission. In many cases, members utilize data in order to propose and convince their internal stakeholders for continued support. One of the data points that can be used for sponsorship justification is traffic to content that is generated by the Foundation. 

After researching potential options, we have settled upon [Plausible](https://plausible.io/) as an analytics solution to meet both the privacy and data requirements for the website. Plausible never uses cookies, does no tracking across websites, and never collects personal data. The use of Plausible does not require the site to have a cookie or GDPR banner. It is lightweight and provides the simple analytics that the Foundation is seeking. And Plausible is [open source](https://github.com/plausible/analytics/) so anyone can see how the product is working under the hood.

In addition, we are considering plans to publicly and continuously share the website statistics from Plausible for everyone to see. 

The Rust Foundation strives to be as transparent as possible with how it is conducting its operations and believes that it has found a solution that balances the privacy concerns of the Rust community with the insights that basic website analytics can provide. 