### PR TITLE
[News] Announcing Cloud Compute Initiative

### DIFF
--- a/news/2021-11-16-news-announcing-cloud-compute-initiative.md
+++ b/news/2021-11-16-news-announcing-cloud-compute-initiative.md
@@ -1,0 +1,28 @@
+---
+layout: news
+title: Rust Foundation Announces Cloud Compute Program
+description: Infrastructure contributions from AWS, Microsoft Azure, and Google Cloud will give Rust maintainers free access to cloud compute to reduce development time and personal expenses
+tags:
+  - programs
+  - cloud compute
+---
+
+Nov. 16, 2021 WAKEFIELD, Mass – The [Rust Foundation](https://foundation.rust-lang.org/), an independent non-profit dedicated to supporting the [Rust Project](https://www.rust-lang.org/), today announced the Rust Foundation Cloud Compute Program, a new initiative to provide free compute for Rust Project maintainers around the world. Through infrastructure credits provided by Amazon Web Services, Inc. (AWS), Microsoft Azure, and Google Cloud, Rust maintainers will have free access to high-powered, cloud compute that will dramatically reduce the time spent building and testing language changes and updates.
+
+The rapid adoption of the Rust programming language has made the Rust developer community the fastest growing in the last two years<sup>1</sup> and created unprecedented demand for the work of the engineers maintaining and contributing to the open source Rust Project and its ecosystem. Committing code to the Rust Project is a multi-step process where one change request frequently takes as long as an hour to complete, usually tying up maintainers’ private, local machines. Today, compiling the Rust compiler on a 4-core CPU, that is typically found in a standard laptop, takes up to 15 minutes with another 5-10 minutes for tests. However, a 96-core cloud virtual machine can complete the same build in less than five minutes with tests completing in 35 seconds. 
+
+With the Rust Foundation Cloud Compute Program, maintainers will have access to cloud compute around the world to build and test code, enabling them to be more efficient in their development of Rust.
+
+“The momentum behind the Rust programming language is undeniable, and it is critical to recognize and support the dedicated Rust maintainers, many of whom are volunteers,” said Rust Foundation Chairwoman Shane Miller, who is also a Senior Engineering Manager at AWS. “Giving all maintainers access to powerful cloud compute will mean that developers are spending their time on code, not waiting for builds. This can save the Rust compiler team thousands of hours every month.”  
+
+“The stated focus of the Rust Foundation is to support the set of highly dedicated and talented maintainers that govern and develop the project,” said Joel Marcey, Member Director at the Rust Foundation and Staff Developer Advocate at Meta (formerly Facebook). “It is my hope that providing these free cloud-based computing resources will be just one of many Foundation initiatives that enable a new level of efficiency, productivity and happiness for those working on the Rust core.”
+
+Nell Shamrell-Harrington, Principal Software Engineer at Microsoft and Rust Foundation Member Director added, “An Open Source ecosystem is only as strong as its maintainers and their ability to contribute. We are proud to provide compute power on Microsoft Azure to support the continued development of the Rust language.”
+
+For more about the Rust Foundation, visit our [website](https://foundation.rust-lang.org/) and [learn about becoming a member](https://foundation.rust-lang.org/info/become-a-member/). Follow us on [Twitter](https://twitter.com/rust_foundation) and [LinkedIn](https://www.linkedin.com/company/rust-foundation/) to stay up to date.
+
+## About the Rust Foundation
+
+[The Rust Foundation](https://foundation.rust-lang.org/) is an independent, non-profit organization with a mission to support the Rust Project. It perpetuates and accelerates innovation, connecting the needs of maintainers with the resources of companies in a collaborative, transparent community that builds awareness and appreciation of Rust, including its positive impact on businesses and the planet. Learn more at foundation.rust-lang.org.
+
+<sup>[1] <a href="https://www.zdnet.com/article/top-programming-languages-most-popular-and-fastest-growing-choices-for-developers/">Top programming languages: Most popular and fastest growing choices for developers</sup>


### PR DESCRIPTION
Putting it on our website as well as [external](https://www.businesswire.com/news/home/20211116005828/en/Rust-Foundation-Announces-Cloud-Compute-Program)