### PR TITLE
Refresh home page with just one button

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -7,7 +7,6 @@ eleventyNavigation:
 <section class="container" id="mission">
     <h1>Good software is built by happy, well-supported people</h1>
     <h2>The Rust Foundation is an independent non-profit organization to steward the <a href="https://www.rust-lang.org">Rust programming language</a> and ecosystem, with a unique focus on supporting the set of maintainers that govern and develop the project.</h2>
-    <div class="cta-white button"><a href="/posts/2021-02-08-hello-world/">Learn more about how we're different</a></div>
     <div class="cta-gradient button"><a href="/info/become-a-member">Become a Member</a></div>
 </section>
 


### PR DESCRIPTION
Just keeping the become a member button on the front page as we have grown our assets across the site to learn more about the Foundation through a bunch of different paths and channels.