### PR TITLE
Fix home page member images

### DIFF
--- a/_includes/memberslist-small.njk
+++ b/_includes/memberslist-small.njk
@@ -4,7 +4,7 @@
     <li>
         <div class="member">
         {% if member.data.logo %}
-            <a href="{{ member.data.url }}" rel="nofollow"><img src="/img/member/{{ member.data.logo }}" alt="{{ member.data.name }}"/></a>
+            <a href="{{ member.data.url }}" rel="nofollow"><img src="{{ member.data.logo }}" alt="{{ member.data.name }}"/></a>
         {% endif %}
         </div>
     </li>


### PR DESCRIPTION
After updating member imaging handling for CloudCannon, forgot to update home page path.