### PR TITLE
Add client side redirect for removed Board page

### DIFF
--- a/_includes/layouts/redirect.njk
+++ b/_includes/layouts/redirect.njk
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="0; URL='{{ destination }}'" />
+  <title>Redirecting to: {{ destination }}</title>
+</head>
+<body>
+  <!-- Redirect page -->
+</body>
+</html>

--- a/board.njk
+++ b/board.njk
@@ -1,0 +1,5 @@
+---
+layout: layouts/redirect.njk
+permalink: "/board/"
+destination: "/about/"
+---


### PR DESCRIPTION
Since we are currently using GitHub Pages, we don't have server side infrastructure for 301-type redirects right now. Until we move hosting to something that supports this, we can use client redirects as a workaround

Ref: https://github.com/11ty/eleventy/issues/510#issuecomment-630682384