### PR TITLE
fix(img): fix max-width related of img 'AMA'

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -214,6 +214,9 @@ main {
   border-bottom: 1px var(--lightorange) dotted;
   padding-bottom: 4em;
 }
+#special-content div img {
+  max-width: 100%;
+}
 #mission h1, #special-content h1, #news h1, #posts h1, #events h1 { /* FIXME why are we even using more than one h1 on a page */
     margin: 2em 0 1em 0;
     font-size: 2em;


### PR DESCRIPTION
This PR aims to set a `max-width` for the `img` about the **'Ask Me Anything - AMA'** inside the section with `id="special-content"`.

I also intended to send a fix for the main `<h1>` with **'Rust Foundation'**, but then I saw that there are already other PR's on this.

Thank you!