### PR TITLE
layouts/news: Add missing `byline`

### DIFF
--- a/_includes/layouts/news.njk
+++ b/_includes/layouts/news.njk
@@ -6,6 +6,7 @@ templateClass: tmpl-news
   <section class="container post">
       <h1>{{ title }}</h1>
       <h2>{{ description }}</h2>
+      {% if byline %}<div class="post-byline">by {{ byline }}</div>{% endif %}
       <time class="post-date" datetime="{{ date | htmlDateString }}">{{ date | readableDate }}</time>
       <div class="content">
           {{ content | safe }}

--- a/css/index.css
+++ b/css/index.css
@@ -287,6 +287,11 @@ main {
   font-size: 1.1875em; /* 19px /16 */
   font-weight: 700;
 }
+.post-byline {
+  font-size: 1.1875em; /* 19px /16 */
+  margin: 1em 0;
+  color: var(--darkgray);
+}
 .post-date {
   font-size: 1.1875em; /* 19px /16 */
   color: var(--darkgray);


### PR DESCRIPTION
This somehow went missing when we moved from "posts" to "news" (see https://github.com/rustfoundation/foundation.rust-lang.org/pull/176) and broke a few older posts that were using this field.

Example:

(the "by Rust Foundation Board of Directors" line)

![Bildschirmfoto 2023-06-20 um 09 58 59](https://github.com/rustfoundation/foundation.rust-lang.org/assets/141300/a8712292-9317-4942-9bbf-663df03d92ec)
