### PR TITLE
Adjust metadata for latest crates.io guest blog post

### DIFF
--- a/news/a-note-on-data-retention-data-privacy-standards-from-the-crates-io-team.md
+++ b/news/a-note-on-data-retention-data-privacy-standards-from-the-crates-io-team.md
@@ -1,12 +1,13 @@
 ---
 title: A Note on Data Retention & Data Privacy Standards From the crates.io Team
-byline:
+byline: the crates.io team
 description: >-
   This blog post is a guest contribution from the crates.io team, intended to
   update the community on our shared, general approach if either the Rust
   Foundation or crates.io teams ever receive a legally-binding request for data.
 date: 2023-06-15T14:00:00Z
 tags:
+  - crates.io
   - guest blog series
 index: false
 layout: layouts/news.njk


### PR DESCRIPTION
Similar to previous crates.io posts I've added the `crates.io` tag to the post and I've also adjusted the `byline` field, which #415 will enable us to show again.