### PR TITLE
replace "Core" with "Leadership Council"

### DIFF
--- a/board/markrousskov.md
+++ b/board/markrousskov.md
@@ -1,6 +1,6 @@
 ---
 name: Mark Rousskov
-title: Secretary, Project Director, Core
+title: Secretary, Project Director, Leadership Council
 ferris: /img/ferris/mark.png
 headshot: /img/headshot/mark.png
 ---

--- a/board/ryanlevick.md
+++ b/board/ryanlevick.md
@@ -1,5 +1,5 @@
 ---
 name: Ryan Levick
-title: Project Director, Core Team
+title: Project Director, Leadership Council
 headshot: /img/headshot/ryan.jpg
 ---


### PR DESCRIPTION
I'm admittedly assuming that the existing Core verbiage is a reference to the since dissolved Core Team, and that it could/should probably be updated to reflect such, as well as that Mark and Ryan are now also on the Leadership Council.

Happy to change or close this if this was an incorrect assumption though