### PR TITLE
Update version of actions/cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
@@ -21,7 +21,7 @@ jobs:
           node-version: '14.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
v2 of `cache` is going to stop working. 

> Starting February 1st, 2025, we are closing down v1-v2 of actions/cache (read more about it in this changelog announcement) as well as all previous versions of the @actions/cache package in actions/toolkit. Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.
> 
> What you need to do:
> We strongly encourage you to update your workflows to begin using a supported version of actions/cache, and upgrade your actions or other products that depend on the @actions/cache package to 4.0.0 or above.
> 
> Supported versions and tags:
> 
> actions/cache:
> actions/cache@v4
> actions/cache@v3
> actions/cache@v4.2.0
> actions/cache@v3.4.0
> @actions/cache package in actions/toolkit: 4.0.0
> 
> Cached entries within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.