### PR TITLE
fixed: typo

### DIFF
--- a/news/rust-foundation-in-review-2024-annual-report-preview.md
+++ b/news/rust-foundation-in-review-2024-annual-report-preview.md
@@ -39,7 +39,7 @@ Thank you to all our members for their support over the past year! We would part
 ### Silver:
 
 * Accelerant
-* Adorysys
+* Adorsys
 * Astral
 * Devolutions
 * Filecoin Foundation


### PR DESCRIPTION
I think there was a little `typo` with the `Adorsys` spelling